### PR TITLE
Add banana pattern for reuse in other effects

### DIFF
--- a/res/graph.json
+++ b/res/graph.json
@@ -35,7 +35,8 @@
       "L": "WaveyPop.render",
       "M": "greetz.render",
       "N": "sheipz.render",
-      "O": "sheipzidee.render"
+      "O": "sheipzidee.render",
+      "P": "NinetiesPatterns.render"
     }
   },
   {
@@ -164,6 +165,13 @@
     "type": "sheipzideeNode",
     "options": {
       "shader": "sheipzidee"
+    }
+  },
+  {
+    "id": "NinetiesPatterns",
+    "type": "NinetiesPatternsNode",
+    "options": {
+      "shader": "NinetiesPatterns"
     }
   }
 ]

--- a/src/NinetiesPatternsNode.js
+++ b/src/NinetiesPatternsNode.js
@@ -1,0 +1,13 @@
+(function(global) {
+  class NinetiesPatternsNode extends NIN.ShaderNode {
+    constructor(id, options) {
+      super(id, options);
+    }
+
+    update(frame) {
+      this.uniforms.frame.value = frame;
+    }
+  }
+
+  global.NinetiesPatternsNode = NinetiesPatternsNode;
+})(this);

--- a/src/SceneSwitcherNode.js
+++ b/src/SceneSwitcherNode.js
@@ -19,6 +19,7 @@
           M: new NIN.TextureInput(),
           N: new NIN.TextureInput(),
           O: new NIN.TextureInput(),
+          P: new NIN.TextureInput(),
         },
         outputs: {
           render: new NIN.TextureOutput(),
@@ -43,6 +44,7 @@
       this.inputs.M.enabled = false;
       this.inputs.N.enabled = false;
       this.inputs.O.enabled = false;
+      this.inputs.P.enabled = false;
 
       let selectedScene;
       if (BEAN < 48 * 4) {
@@ -87,8 +89,10 @@
         selectedScene = this.inputs.O;
       } else if (BEAN < 12 * 4 * 48) {
         selectedScene = this.inputs.N;
-      } else if (BEAN < 12 * 4 * 56) {
+      } else if (BEAN < 12 * 4 * 50) {
         selectedScene = this.inputs.E;
+      } else if (BEAN < 12 * 4 * 60) {
+        selectedScene = this.inputs.P;
       } else if (BEAN < 12 * 4 * 70) {
         selectedScene = this.inputs.M;
       } else if (BEAN < 12 * 4 * 72) {

--- a/src/shaders/NinetiesPatterns/fragment.glsl
+++ b/src/shaders/NinetiesPatterns/fragment.glsl
@@ -1,0 +1,65 @@
+uniform float frame;
+uniform sampler2D tDiffuse;
+
+varying vec2 vUv;
+
+float rmin(float a, float b, float r) {
+    vec2 u = max(vec2(r - a,r - b), vec2(0));
+    return max(r, min (a, b)) - length(u);
+}
+
+float banana_body(vec2 p, float size) {
+    float r = length(p) - size;
+    r = max(r, -(length(p - vec2(size * 0.3)) - size));
+    r = max(r, length(p - vec2(-size * 0.25)) - size);
+
+    return r;
+}
+
+float banana_head_butt(vec2 p, float size) {
+    float r = length(p) - size;
+    r = max(r, -(length(p - vec2(size * 0.3)) - size));
+    r = max(r, -(length(p - vec2(-size * 0.25)) - size));
+    r = rmin(r, max(abs(p.x + size * 0.5) - 0.015 * size, abs(p.y - size * 0.9) - 0.1 * size), 0.275 * size);
+    r = rmin(r, max(abs(p.x - size * 0.75), abs(p.y + size * 0.6)), 0.225 * size);
+
+    return r;
+}
+
+vec3 bananaPattern(vec2 p) {
+    float size = 0.15;
+
+    // Repeat
+    vec2 rep = vec2(size * 2.75);
+    float px = floor(p.x / rep.x);
+    p.y += px * rep.y * 0.5;
+    p = mod(p, rep);
+    p -= rep * 0.5;
+
+    // Objects
+    float banana_bodies = smoothstep(0., 0.01, banana_body(p, size));
+    float banana_head_butts = smoothstep(0., 0.01, banana_head_butt(p, size));
+
+    // Bodies
+    float banana_bodies_shadow = smoothstep(0., 0.01, banana_body(p - vec2(0.2 * size), size));
+
+    float bg = banana_bodies * banana_head_butts;
+
+    return (
+        vec3(0.35, 0.75, 1.) * bg +
+        vec3(1., 1., 0.) * (1. - banana_bodies) +
+        vec3(0.5, 0.3, 0.15) * (1. - banana_head_butts)
+    ) - (
+        vec3(0.8, 0., 0.) * banana_bodies_shadow
+    );
+}
+
+void main() {
+    vec2 p = vUv;
+    p = 2. * p - 1.;
+    p.x *= 16. / 9.;
+
+    vec3 currentPattern = bananaPattern(p);
+
+    gl_FragColor = vec4(currentPattern, 0.);
+}

--- a/src/shaders/NinetiesPatterns/uniforms.json
+++ b/src/shaders/NinetiesPatterns/uniforms.json
@@ -1,0 +1,4 @@
+{
+    "tDiffuse": { "type": "t", "value": null },
+    "frame": { "type": "f", "value": 0.0 }
+}

--- a/src/shaders/NinetiesPatterns/vertex.glsl
+++ b/src/shaders/NinetiesPatterns/vertex.glsl
@@ -1,0 +1,8 @@
+uniform sampler2D tDiffuse;
+
+varying vec2 vUv;
+
+void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}


### PR DESCRIPTION
My plan for this shader is to implement many of the mtv-background patterns: 
![ba](https://i.redd.it/b0euqqjryw201.png)

So that it can be reused in other effects, like the background of the mtv logo.

Right now it implements a banana pattern:
![2018-07-10--1531255189_1248x697_scrot](https://user-images.githubusercontent.com/2737080/42536466-7449909c-8492-11e8-9417-eff93dd637db.png)
