### PR TITLE
Add zebra, geopard and crazy mtv pattern

### DIFF
--- a/src/NinetiesPatternsNode.js
+++ b/src/NinetiesPatternsNode.js
@@ -9,7 +9,7 @@
     update(frame) {
       this.uniforms.frame.value = frame;
       this.uniforms.patternSize.value = this.patternSize;
-      this.uniforms.effectNum.value = (Math.sin((frame / 60.) * 5.) > 0.) ? 0. : 1.;
+      this.uniforms.effectNum.value = 1.;
     }
   }
 


### PR DESCRIPTION
The ninetiesShaderNode can now procedurally generate the following patterns:

Intended to be use as input to the mtv intro and other scenes

![2018-07-11--1531337053_682x385_scrot](https://user-images.githubusercontent.com/2737080/42595020-3859b7dc-8551-11e8-8850-89221ceb79d7.png)
![2018-07-11--1531337026_682x383_scrot](https://user-images.githubusercontent.com/2737080/42595029-3b6c022c-8551-11e8-8117-f8de6af0dfe0.png)
![2018-07-11--1531337015_681x391_scrot](https://user-images.githubusercontent.com/2737080/42595032-3de14a08-8551-11e8-8f3a-d420c4bfdca2.png)
![2018-07-11--1531337002_680x385_scrot](https://user-images.githubusercontent.com/2737080/42595035-40362742-8551-11e8-8332-be9f96ba16bd.png)
