### PR TITLE
Remove one more invalid texture load

### DIFF
--- a/src/sheipzideeNode.js
+++ b/src/sheipzideeNode.js
@@ -2,8 +2,6 @@
   class sheipzideeNode extends NIN.ShaderNode {
     constructor(id, options) {
       super(id, options);
-
-      this.texture = Loader.loadTexture('res/zentangles/paper.jpg');
     }
 
     update(frame) {


### PR DESCRIPTION
This texture load seems unused, and refers to an invalid path. This
breaks the demo in compiled mode.