### PR TITLE
Confine end of number transitions better in time

### DIFF
--- a/src/zentangleVision.js
+++ b/src/zentangleVision.js
@@ -138,17 +138,18 @@
       }
       // Region add numbers end
 
-      if(this.fourShoutBean < BEAN){
-        let number1PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean, 4755, this.number1originalPosition, this.number2originalPosition, BEAN);
+      let endFinalTransition = 4720;
+      if(this.fourShoutBean < BEAN && BEAN < endFinalTransition){
+        let number1PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean, endFinalTransition, this.number1originalPosition, this.number2originalPosition, BEAN);
         this.number1.position.x = number1PosNow.x;
         this.number1.position.y = number1PosNow.y;
-        let number2PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean,4755, this.number2originalPosition, this.number3originalPosition, BEAN);
+        let number2PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean, endFinalTransition, this.number2originalPosition, this.number3originalPosition, BEAN);
         this.number2.position.x = number2PosNow.x;
         this.number2.position.y = number2PosNow.y;
-        let number3PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean,4755, this.number3originalPosition, this.number4originalPosition, BEAN);
+        let number3PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean, endFinalTransition, this.number3originalPosition, this.number4originalPosition, BEAN);
         this.number3.position.x = number3PosNow.x;
         this.number3.position.y = number3PosNow.y;
-        let number4PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean,4755, this.number4originalPosition, this.number1originalPosition, BEAN);
+        let number4PosNow = getPositionForGivenBeanWhenMovingBetwennTwoPoints(this.fourShoutBean, endFinalTransition, this.number4originalPosition, this.number1originalPosition, BEAN);
         this.number4.position.x = number4PosNow.x;
         this.number4.position.y = number4PosNow.y;
       } // This ends when bird scene starts at bean #4776


### PR DESCRIPTION
This makes it so that the numbers don't continue to float after the
transition has supposedly ended.